### PR TITLE
feat: Theme option tabs

### DIFF
--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -271,16 +271,17 @@ export class RenderThemeEditor extends React.Component {
                     </DialogBody>
                 ),
             }));
-        const pageWithoutTitle = otherPages.find((e) => !e.title);
-        const pages = [
-            { ...pageWithoutTitle, title: locale.customThemeSettingsConfig },
-            ...otherPages.filter((e) => e !== pageWithoutTitle),
-            colorPage
-        ];
+		const pageWithoutTitle = {
+			...otherPages.find((e) => !e.title),
+			title: locale.customThemeSettingsConfig,
+		};
+		const tabs = themeHasTabs
+			? otherPages.filter((e) => e !== pageWithoutTitle)
+			: [pageWithoutTitle];
         const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
 
         return (
-			<SidebarNavigation pages={pages} title={title} />
+			<SidebarNavigation className="AAAAAAAtesting" pages={[...tabs, colorPage]} title={title} />
 		);
     }
 }

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -56,14 +56,14 @@ interface ColorProps {
 }
 
 const ThemeEditorContainer: React.FC = ({ children }) => (
-	<ModalPosition>
-		<style>
-			{`.DialogBody { margin-bottom: 48px; }
+    <ModalPosition>
+        <style>
+            {`.DialogBody { margin-bottom: 48px; }
             input.colorPicker { margin-left: 10px !important; border: unset !important; min-width: 38px; width: 38px !important; height: 38px; !important; background: transparent; padding: unset !important; }`}
-		</style>
+        </style>
 
         {children}
-	</ModalPosition>
+    </ModalPosition>
 );
 
 export class RenderThemeEditor extends React.Component {
@@ -255,13 +255,13 @@ export class RenderThemeEditor extends React.Component {
                     </DialogBody>
                 ),
             }));
-		const pageWithoutTitle = {
-			...otherPages.find((e) => !e.title),
-			title: locale.customThemeSettingsConfig,
-		};
-		const tabs = themeHasTabs
-			? otherPages.filter((e) => e !== pageWithoutTitle)
-			: [pageWithoutTitle];
+        const pageWithoutTitle = {
+            ...otherPages.find((e) => !e.title),
+            title: locale.customThemeSettingsConfig,
+        };
+        const tabs = themeHasTabs
+            ? otherPages.filter((e) => e !== pageWithoutTitle)
+            : [pageWithoutTitle];
 
         const className = `${settingsClasses.SettingsModal} ${settingsClasses.DesktopPopup}`;
         const pages = [...tabs, colorPage];
@@ -269,17 +269,17 @@ export class RenderThemeEditor extends React.Component {
 
         return (
             <ThemeEditorContainer>
-				{!themeHasTabs && !themeHasColors && (
-					<style>{`
+                {!themeHasTabs && !themeHasColors && (
+                    <style>{`
                         .PageListColumn {
                             display: none !important;
                         }
                     `}</style>
-				)}
+                )}
 
                 {/* @ts-ignore: Hasn't been added to DFL yet */}
                 <SidebarNavigation className={className} pages={pages} title={title} />
             </ThemeEditorContainer>
-		);
+        );
     }
 }

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -8,6 +8,8 @@ import {
     DialogHeader,
     Dropdown,
     Millennium,
+    SidebarNavigation,
+    type SidebarNavigationPage,
     SingleDropdownOption,
     Toggle,
     pluginSelf,
@@ -197,6 +199,45 @@ export class RenderThemeEditor extends React.Component {
     
         const themeConditions: Conditions = activeTheme.data.Conditions
         const savedConditions = pluginSelf?.conditionals?.[activeTheme.native] as ConditionsStore
+
+		const pages: SidebarNavigationPage[] = Object.entries(themeConditions)
+			.reduce<{ title: string; conditions: Conditions[] }[]>((vec, entry) => {
+				const [name, patch] = entry;
+				const { tab } = patch;
+				const condition = { [name]: patch };
+				const page = {
+					title: tab,
+					conditions: [condition],
+				};
+
+				const foundTab = vec.find((e) => e.title === tab);
+				if (foundTab) {
+					foundTab.conditions.push(condition);
+					return vec;
+				}
+
+				vec.push(page);
+				return vec;
+			}, [])
+			.map(({ title, conditions }) => ({
+				title,
+				content: (
+					<DialogBody className={Classes.SettingsDialogBodyFade}>
+						{Object.entries(
+							conditions.reduce((a, b) => Object.assign(a, b)),
+						).map(([key, value]) => (
+							<this.RenderComponent
+								condition={key}
+								store={savedConditions}
+								value={value}
+							/>
+						))}
+					</DialogBody>
+				),
+			}));
+        const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
+
+        return <SidebarNavigation pages={pages} title={title} />; 
 
         return (
             <div className="ModalPosition" tabIndex={0}>

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -181,13 +181,13 @@ export class RenderThemeEditor extends React.Component {
             })
         }, [])
 
-		return (
-			<>
-				{themeColors?.map((color, index) => (
-					<this.RenderColorComponent color={color} index={index} />
-				))}
-			</>
-		);
+        return (
+            <>
+                {themeColors?.map((color, index) => (
+                    <this.RenderColorComponent color={color} index={index} />
+                ))}
+            </>
+        );
     }
 
     render() {
@@ -196,54 +196,54 @@ export class RenderThemeEditor extends React.Component {
         const themeConditions: Conditions = activeTheme.data.Conditions
         const savedConditions = pluginSelf?.conditionals?.[activeTheme.native] as ConditionsStore
 
-		const colorPage: SidebarNavigationPage = {
+        const colorPage: SidebarNavigationPage = {
             visible: !!activeTheme.data.RootColors,
-			title: "Colors",
-			content: (
-				<DialogBody className={Classes.SettingsDialogBodyFade}>
-					<this.RenderColorsOpts />
-				</DialogBody>
-			),
-		};
-		const otherPages: SidebarNavigationPage[] = Object.entries(themeConditions)
-			.reduce<{ title: string; conditions: Conditions[] }[]>((vec, entry) => {
-				const [name, patch] = entry;
-				const { tab } = patch;
-				const condition = { [name]: patch };
-				const page = {
-					title: tab,
-					conditions: [condition],
-				};
+            title: "Colors",
+            content: (
+                <DialogBody className={Classes.SettingsDialogBodyFade}>
+                    <this.RenderColorsOpts />
+                </DialogBody>
+            ),
+        };
+        const otherPages: SidebarNavigationPage[] = Object.entries(themeConditions)
+            .reduce<{ title: string; conditions: Conditions[] }[]>((vec, entry) => {
+                const [name, patch] = entry;
+                const { tab } = patch;
+                const condition = { [name]: patch };
+                const page = {
+                    title: tab,
+                    conditions: [condition],
+                };
 
-				const foundTab = vec.find((e) => e.title === tab);
-				if (foundTab) {
-					foundTab.conditions.push(condition);
-					return vec;
-				}
+                const foundTab = vec.find((e) => e.title === tab);
+                if (foundTab) {
+                    foundTab.conditions.push(condition);
+                    return vec;
+                }
 
-				vec.push(page);
-				return vec;
-			}, [])
-			.map(({ title, conditions }) => ({
-				title,
-				content: (
-					<DialogBody className={Classes.SettingsDialogBodyFade}>
-						{Object.entries(
-							conditions.reduce((a, b) => Object.assign(a, b)),
-						).map(([key, value]) => (
-							<this.RenderComponent
-								condition={key}
-								store={savedConditions}
-								value={value}
-							/>
-						))}
-					</DialogBody>
-				),
-			}));
-		const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
+                vec.push(page);
+                return vec;
+            }, [])
+            .map(({ title, conditions }) => ({
+                title,
+                content: (
+                    <DialogBody className={Classes.SettingsDialogBodyFade}>
+                        {Object.entries(
+                            conditions.reduce((a, b) => Object.assign(a, b)),
+                        ).map(([key, value]) => (
+                            <this.RenderComponent
+                                condition={key}
+                                store={savedConditions}
+                                value={value}
+                            />
+                        ))}
+                    </DialogBody>
+                ),
+            }));
+        const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
 
-		return (
-			<SidebarNavigation pages={[...otherPages, colorPage]} title={title} />
-		);
+        return (
+            <SidebarNavigation pages={[...otherPages, colorPage]} title={title} />
+        );
     }
 }

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -6,6 +6,7 @@ import {
     DialogHeader,
     Dropdown,
     Millennium,
+    ModalPosition,
     SidebarNavigation,
     type SidebarNavigationPage,
     SingleDropdownOption,
@@ -53,6 +54,17 @@ interface ColorProps {
     hex: string,
     defaultColor: string
 }
+
+const ThemeEditorContainer: React.FC = ({ children }) => (
+	<ModalPosition>
+		<style>
+			{`.DialogBody { margin-bottom: 48px; }
+            input.colorPicker { margin-left: 10px !important; border: unset !important; min-width: 38px; width: 38px !important; height: 38px; !important; background: transparent; padding: unset !important; }`}
+		</style>
+
+        {children}
+	</ModalPosition>
+);
 
 export class RenderThemeEditor extends React.Component {
 
@@ -199,34 +211,6 @@ export class RenderThemeEditor extends React.Component {
         const themeHasColors = !!activeTheme.data.RootColors;
         const themeHasTabs = entries.map((e) => e[1]).some((e) => !!e.tab);
 
-        if (!themeHasTabs && !themeHasColors) {
-            return (
-                <div className="ModalPosition" tabIndex={0}>
-                    <style>
-                        {
-                            `.DialogBody.${Classes.SettingsDialogBodyFade}:last-child { padding-bottom: 65px; }
-                            input.colorPicker { margin-left: 10px !important; border: unset !important; min-width: 38px; width: 38px !important; height: 38px; !important; background: transparent; padding: unset !important; }`
-                        }
-                    </style>
-
-                    <div className="ModalPosition_Content" style={{width: "100vw", height: "100vh"}}>
-                        <div className={`${Classes.PagedSettingsDialog} ${Classes.SettingsModal} ${Classes.DesktopPopup} Panel`}>
-                            <div className="DialogContentTransition Panel" style={{minWidth: "100vw"}}>
-                                <div className={`DialogContent _DialogLayout ${Classes.PagedSettingsDialog_PageContent} `}>
-                                    <div className="DialogContent_InnerWidth">
-                                        <DialogHeader>{locale.customThemeSettingsConfig}</DialogHeader>
-                                        <DialogBody className={Classes.SettingsDialogBodyFade}>
-                                            {Object.entries(themeConditions).map(([key, value]) => <this.RenderComponent condition={key} store={savedConditions} value={value}/>)}
-                                        </DialogBody>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            );
-        }
-
         const colorPage: SidebarNavigationPage = {
             visible: themeHasColors,
             title: locale.customThemeSettingsColors,
@@ -278,10 +262,24 @@ export class RenderThemeEditor extends React.Component {
 		const tabs = themeHasTabs
 			? otherPages.filter((e) => e !== pageWithoutTitle)
 			: [pageWithoutTitle];
+
+        const className = `${settingsClasses.SettingsModal} ${settingsClasses.DesktopPopup}`;
+        const pages = [...tabs, colorPage];
         const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
 
         return (
-			<SidebarNavigation className="AAAAAAAtesting" pages={[...tabs, colorPage]} title={title} />
+            <ThemeEditorContainer>
+				{!themeHasTabs && !themeHasColors && (
+					<style>{`
+                        .PageListColumn {
+                            display: none !important;
+                        }
+                    `}</style>
+				)}
+
+                {/* @ts-ignore: Hasn't been added to DFL yet */}
+                <SidebarNavigation className={className} pages={pages} title={title} />
+            </ThemeEditorContainer>
 		);
     }
 }

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -277,7 +277,7 @@ export class RenderThemeEditor extends React.Component {
                     `}</style>
                 )}
 
-                {/* @ts-ignore: Hasn't been added to DFL yet */}
+                {/* @ts-ignore: className hasn't been added to DFL yet */}
                 <SidebarNavigation className={className} pages={pages} title={title} />
             </ThemeEditorContainer>
         );

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -18,8 +18,6 @@ import { BBCodeParser } from "../components/BBCodeParser";
 import { Field } from "../custom_components/Field";
 import { Conditions, ConditionsStore, ICondition, ThemeItem } from "../types"
 import { settingsClasses } from "../classes"
-import { locale } from "../locales"
-import { SettingsDialogSubHeader } from "../components/SettingsDialogSubHeader";
 
 interface ConditionalComponent {
     condition: string,
@@ -173,25 +171,23 @@ export class RenderThemeEditor extends React.Component {
     }
 
     RenderColorsOpts: React.FC = () => {
-        const activeTheme: ThemeItem = pluginSelf.activeTheme as ThemeItem
         const [themeColors, setThemeColors] = useState<ColorProps[]>()
 
         useEffect(() => {
-            if (activeTheme?.data?.RootColors) {
-                Millennium.callServerMethod("cfg.get_color_opts")
-                .then((result: any) => {
-                    console.log(JSON.parse(result) as ColorProps[])
-                    setThemeColors(JSON.parse(result) as ColorProps[])
-                })
-            }
+            Millennium.callServerMethod("cfg.get_color_opts")
+            .then((result: any) => {
+                console.log(JSON.parse(result) as ColorProps[])
+                setThemeColors(JSON.parse(result) as ColorProps[])
+            })
         }, [])
 
-        return themeColors && <DialogControlsSection>
-            <SettingsDialogSubHeader>{locale.customThemeSettingsColorsHeader}</SettingsDialogSubHeader>
-            <DialogBodyText className='_3fPiC9QRyT5oJ6xePCVYz8'>{locale.customThemeSettingsColorsDescription}</DialogBodyText>
-
-            {themeColors?.map((color: any, index: number) => <this.RenderColorComponent color={color} index={index}/>)}
-        </DialogControlsSection>      
+		return (
+			<>
+				{themeColors?.map((color, index) => (
+					<this.RenderColorComponent color={color} index={index} />
+				))}
+			</>
+		);
     }
 
     render() {
@@ -200,7 +196,16 @@ export class RenderThemeEditor extends React.Component {
         const themeConditions: Conditions = activeTheme.data.Conditions
         const savedConditions = pluginSelf?.conditionals?.[activeTheme.native] as ConditionsStore
 
-		const pages: SidebarNavigationPage[] = Object.entries(themeConditions)
+		const colorPage: SidebarNavigationPage = {
+            visible: !!activeTheme.data.RootColors,
+			title: "Colors",
+			content: (
+				<DialogBody className={Classes.SettingsDialogBodyFade}>
+					<this.RenderColorsOpts />
+				</DialogBody>
+			),
+		};
+		const otherPages: SidebarNavigationPage[] = Object.entries(themeConditions)
 			.reduce<{ title: string; conditions: Conditions[] }[]>((vec, entry) => {
 				const [name, patch] = entry;
 				const { tab } = patch;
@@ -237,6 +242,8 @@ export class RenderThemeEditor extends React.Component {
 			}));
 		const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
 
-		return <SidebarNavigation pages={pages} title={title} />; 
+		return (
+			<SidebarNavigation pages={[...otherPages, colorPage]} title={title} />
+		);
     }
 }

--- a/assets/src/custom_components/ThemeEditor.tsx
+++ b/assets/src/custom_components/ThemeEditor.tsx
@@ -235,41 +235,8 @@ export class RenderThemeEditor extends React.Component {
 					</DialogBody>
 				),
 			}));
-        const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
+		const title = `Editing ${activeTheme?.data?.name ?? activeTheme.native}`;
 
-        return <SidebarNavigation pages={pages} title={title} />; 
-
-        return (
-            <div className="ModalPosition" tabIndex={0}>
-
-                <style>
-                    {
-                        `.DialogBody.${Classes.SettingsDialogBodyFade}:last-child { padding-bottom: 65px; }
-                        input.colorPicker { margin-left: 10px !important; border: unset !important; min-width: 38px; width: 38px !important; height: 38px; !important; background: transparent; padding: unset !important; }`
-                    }
-                </style>
-
-                <div className="ModalPosition_Content" style={{width: "100vw", height: "100vh"}}>
-                    <div className={`${Classes.PagedSettingsDialog} ${Classes.SettingsModal} ${Classes.DesktopPopup} Panel`}>
-                        <div className="DialogContentTransition Panel" style={{minWidth: "100vw"}}>
-                            <div className={`DialogContent _DialogLayout ${Classes.PagedSettingsDialog_PageContent} `}>
-                                <div className="DialogContent_InnerWidth">
-                                    <DialogHeader>Editing {activeTheme?.data?.name ?? activeTheme.native}</DialogHeader>
-                                    <DialogBody className={Classes.SettingsDialogBodyFade}>
-                                        {themeConditions && <DialogControlsSection>
-                                            <SettingsDialogSubHeader>{locale.customThemeSettingsConfigHeader}</SettingsDialogSubHeader>
-                                            <DialogBodyText className='_3fPiC9QRyT5oJ6xePCVYz8'>{locale.customThemeSettingsConfigDescription}</DialogBodyText>
-                                    
-                                            {Object.entries(themeConditions).map(([key, value]) => <this.RenderComponent condition={key} store={savedConditions} value={value}/>)}
-                                        </DialogControlsSection>}
-                                        <this.RenderColorsOpts/>
-                                    </DialogBody>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        )
+		return <SidebarNavigation pages={pages} title={title} />; 
     }
 }

--- a/assets/src/locales/locales/english.json
+++ b/assets/src/locales/locales/english.json
@@ -28,8 +28,6 @@
     "optionReloadLater": "Reload Later",
     "updatePanelUpdateNotifications": "Push Notifications",
     "updatePanelUpdateNotificationsTooltip": "Get Millennium to give you a reminder when a item in your library has an update!",
-    "customThemeSettingsColorsHeader": "Color Options",
-    "customThemeSettingsColorsDescription": "Customize the colors of your theme.",
-    "customThemeSettingsConfigHeader": "Custom Settings",
-    "customThemeSettingsConfigDescription": "Customize the settings of your theme."
+    "customThemeSettingsColors": "Colors",
+    "customThemeSettingsConfig": "Custom Settings"
 }

--- a/assets/src/patcher/v2/Conditions.ts
+++ b/assets/src/patcher/v2/Conditions.ts
@@ -1,33 +1,23 @@
-import { pluginSelf } from "millennium-lib";
-import {
-	Conditions,
-	ConditionsStore,
-	ThemeItem,
-	ConditionalControlFlowType as ModuleType,
-} from "../../types";
-import { EvaluatePatch } from "../Dispatch";
+import { pluginSelf } from "millennium-lib"
+import { Conditions, ConditionsStore, ThemeItem, ConditionalControlFlowType as ModuleType } from "../../types"
+import { EvaluatePatch } from "../Dispatch"
 
-export const EvaluateConditions = (
-	theme: ThemeItem,
-	title: string,
-	classes: string[],
-	document: Document,
-): void => {
-	const themeConditions: Conditions = theme.data.Conditions;
-	const savedConditions: ConditionsStore =
-		pluginSelf.conditionals[theme.native];
+export const EvaluateConditions = (theme: ThemeItem, title: string, classes: string[], document: Document): void => {
 
-	for (const condition in themeConditions) {
-		if (!themeConditions.hasOwnProperty(condition)) {
-			return;
-		}
+    const themeConditions: Conditions = theme.data.Conditions
+    const savedConditions: ConditionsStore = pluginSelf.conditionals[theme.native]
 
-		if (condition in savedConditions) {
-			const patch =
-				themeConditions[condition].values[savedConditions[condition]];
+    for (const condition in themeConditions) {
 
-			EvaluatePatch(ModuleType.TargetCss, patch, title, classes, document);
-			EvaluatePatch(ModuleType.TargetJs, patch, title, classes, document);
-		}
-	}
-};
+        if (!themeConditions.hasOwnProperty(condition)) {
+            return 
+        }
+
+        if (condition in savedConditions) {
+            const patch = themeConditions[condition].values[savedConditions[condition]]
+
+            EvaluatePatch(ModuleType.TargetCss, patch, title, classes, document)
+            EvaluatePatch(ModuleType.TargetJs, patch, title, classes, document)
+        }
+    }
+}

--- a/assets/src/patcher/v2/Conditions.ts
+++ b/assets/src/patcher/v2/Conditions.ts
@@ -1,23 +1,33 @@
-import { pluginSelf } from "millennium-lib"
-import { Conditions, ConditionsStore, ThemeItem, ConditionalControlFlowType as ModuleType } from "../../types"
-import { EvaluatePatch } from "../Dispatch"
+import { pluginSelf } from "millennium-lib";
+import {
+	Conditions,
+	ConditionsStore,
+	ThemeItem,
+	ConditionalControlFlowType as ModuleType,
+} from "../../types";
+import { EvaluatePatch } from "../Dispatch";
 
-export const EvaluateConditions = (theme: ThemeItem, title: string, classes: string[], document: Document): void => {
+export const EvaluateConditions = (
+	theme: ThemeItem,
+	title: string,
+	classes: string[],
+	document: Document,
+): void => {
+	const themeConditions: Conditions = theme.data.Conditions;
+	const savedConditions: ConditionsStore =
+		pluginSelf.conditionals[theme.native];
 
-    const themeConditions: Conditions = theme.data.Conditions
-    const savedConditions: ConditionsStore = pluginSelf.conditionals[theme.native]
+	for (const condition in themeConditions) {
+		if (!themeConditions.hasOwnProperty(condition)) {
+			return;
+		}
 
-    for (const condition in themeConditions) {
+		if (condition in savedConditions) {
+			const patch =
+				themeConditions[condition].values[savedConditions[condition]];
 
-        if (!themeConditions.hasOwnProperty(condition)) {
-            return 
-        }
-
-        if (condition in savedConditions) {
-            const patch = themeConditions[condition].values[savedConditions[condition]]
-
-            EvaluatePatch(ModuleType.TargetCss, patch, title, classes, document)
-            EvaluatePatch(ModuleType.TargetJs, patch, title, classes, document)
-        }
-    }
-}
+			EvaluatePatch(ModuleType.TargetCss, patch, title, classes, document);
+			EvaluatePatch(ModuleType.TargetJs, patch, title, classes, document);
+		}
+	}
+};

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -45,7 +45,11 @@ export interface Conditions {
 export interface ICondition {
     default?: string;
     description?: string;
-    tab: string;
+    /**
+     * Tab to put the condition in.
+     * If no condition uses them, there will be no tabs.
+     */
+    tab?: string;
     values: {
         [condition: string]: ConditionalControlFlow
     };

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -45,6 +45,7 @@ export interface Conditions {
 export interface ICondition {
     default?: string;
     description?: string;
+    tab: string;
     values: {
         [condition: string]: ConditionalControlFlow
     };

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -47,7 +47,9 @@ export interface ICondition {
     description?: string;
     /**
      * Tab to put the condition in.
+     *
      * If no condition uses them, there will be no tabs.
+     * If some conditions include it, those who don't will be put in a separate tab.
      */
     tab?: string;
     values: {


### PR DESCRIPTION
now theme conditions can include a "tab" key, i.e.
```
{
	"Conditions": {
		"Wallet Visibility": {
			"description": "Show wallet balance on the top right menu",
			"default": "Show",
			"tab": "tab 1",
			"values": {}
		},
		"URL Visibility": {
			"description": "Show URL bar when browsing inside Steam",
			"default": "Show",
			"tab": "tab 2",
			"values": {}
		}
	}
}
```
preview:
![image](https://github.com/user-attachments/assets/a7bcf06b-a23b-46c3-99c3-b59231f2c77f)

closes #93