### PR TITLE
Check if jq is installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,6 +55,7 @@ esac
 command -v curl >/dev/null || { log "curl isn't installed!" >&2; exit 1; }
 command -v tar >/dev/null || { log "tar isn't installed!" >&2; exit 1; }
 command -v grep >/dev/null || { log "grep isn't installed!" >&2; exit 1; }
+command -v jq >/dev/null || { log "jq isn't installed!" >&2; exit 1; }
 
 # download uri
 releases_uri="https://api.github.com/repos/SteamClientHomebrew/Millennium/releases"


### PR DESCRIPTION
I have repeatedly encountered the problem after a clean installation of Arch, when a script tries to run a not installed jq. For some reason, the script did not check whether it was installed or not. On Arch, for example, this package is not included in the standard package groups.