### PR TITLE
improved webkit load performance by ~350ms

### DIFF
--- a/shims/src/index.ts
+++ b/shims/src/index.ts
@@ -85,7 +85,7 @@ function formatCssVarKey(key: string): string {
 
 const StartPreloader = async (port: number, shimList?: string[]) => {
 	logger.log(`Successfully bound to ${isClient ? 'client' : 'webkit'} DOM...`);
-	const socket = await CreateWebSocket('ws://localhost:' + port);
+	const socket = await CreateWebSocket('ws://127.0.0.1:' + port);
 
 	/** Setup IPC */
 	window.MILLENNIUM_IPC_PORT = port;


### PR DESCRIPTION
Improved load time till `ExecutePluginModule` for the plugin webkit is called.
Before: ~1100ms
After: ~750ms
Load time was measured on an app page by adding a `performance.mark` at the start `ExecutePluginModule` and grabbing the event log time from the performance tab in the devtools averaged over 8-10 loads restarting the client twice in between (because for some reason steam's load times vary between boot ups)

It looks like there is not much more time to save since you are dealing with the main thread being full with parsing html or calling steam functions most functions calls or async responses are just pending because the main thread is just busy.