### PR TITLE
Allow millennium to restart steam using different port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ find_package(CURL REQUIRED) # used for web requests.
 target_link_libraries(Millennium CURL::libcurl)
 
 if(WIN32)
-  target_link_libraries(Millennium wsock32 Iphlpapi DbgHelp)
+  target_link_libraries(Millennium wsock32 Iphlpapi DbgHelp comctl32)
 
   if(GITHUB_ACTION_BUILD)
     target_link_libraries(Millennium "D:/a/Millennium/Millennium/Python-3.11.8/PCbuild/win32/python311.lib")


### PR DESCRIPTION
This is not ready:
- It is based of main
- idk if startupParams are collected
- messages are wacky
- choice saved in file, might be needed to be saved in options
- there might be some caveats to using exec on windows
- there's no error handling
 
but the idea is that we say that the port is taken and prompt user about it, then we restart steam with command line arg of the new port and if user checked this will happen w/o prompt: user starts steam -> port taken -> millennium restarts stream with new port.
It'll prob slow down startup but it'll allow seamless port change.