### PR TITLE
Handle arrays in Python FFI

### DIFF
--- a/src/core/_c_py_interop.cc
+++ b/src/core/_c_py_interop.cc
@@ -276,7 +276,7 @@ PyObject* PyObjectFromJson(const nlohmann::json& json)
     PyObject* pObject = nullptr;
     
     if      (json.is_string())         pObject = PyUnicode_FromString(json.get<std::string>().c_str());
-    else if (json.is_number_integer()) pObject = PyLong_FromLong(json.get<int>());
+    else if (json.is_number_integer()) pObject = PyLong_FromLongLong(json.get<long long>());
     else if (json.is_number_float())   pObject = PyFloat_FromDouble(json.get<double>());
     else if (json.is_boolean())        pObject = PyBool_FromLong(json.get<bool>() ? 1 : 0);
     else if (json.is_array())

--- a/src/core/_c_py_interop.cc
+++ b/src/core/_c_py_interop.cc
@@ -302,7 +302,27 @@ PyObject* InvokePythonFunction(const nlohmann::json& jsonData)
             else if (value.is_number_integer()) pValue = PyLong_FromLong(value.get<int>());
             else if (value.is_number_float())   pValue = PyFloat_FromDouble(value.get<double>());
             else if (value.is_boolean())        pValue = PyBool_FromLong(value.get<bool>() ? 1 : 0);
-            
+            else if (value.is_array())
+            {
+                pValue = PyList_New(value.size());
+                int counter = 0;
+                for (auto& item : value)
+                {
+                    PyObject* pItemValue = nullptr;
+
+                    if(item.is_string())                pItemValue = PyUnicode_FromString(item.get<std::string>().c_str());
+                    else if (item.is_number_integer()) pItemValue = PyLong_FromLong(value.get<int>());
+                    else if (item.is_number_float())   pItemValue = PyFloat_FromDouble(value.get<double>());
+                    else if (item.is_boolean())        pItemValue = PyBool_FromLong(value.get<bool>() ? 1 : 0);
+
+                    if( pItemValue )
+                    {
+                        PyList_SetItem(pValue, counter, pItemValue);
+                        Py_DECREF(pItemValue);
+                        counter++;
+                    }
+                }
+            }
 
             else if (value.is_null()) 
             {

--- a/src/core/_c_py_interop.cc
+++ b/src/core/_c_py_interop.cc
@@ -289,8 +289,12 @@ PyObject* PyObjectFromJson(const nlohmann::json& json)
 
             if( pListItem )
             {
-                if(PyList_SetItem(pObject, counter, pListItem) < 0)
+                if(PyList_SetItem(pObject, i, pListItem) < 0)
                 {
+                    Py_DECREF(pObject);
+
+                    LOG_ERROR("Failed to parse list");
+
                     return nullptr;
                 }
                 i++;


### PR DESCRIPTION
Seems like `InvokePythonFunction` at one point passed arrays from JS to Python correctly and Non-Steam Playtimes relied on that. This gets the plugin to work again.