### PR TITLE
fix wrong lib on some sys

### DIFF
--- a/assets/core/util/use_system.py
+++ b/assets/core/util/use_system.py
@@ -3,7 +3,7 @@
 import os
 
 def use_system_libs(callback):
-    system_lib_path = "/usr/lib"  # Replace this if your libcurl location is different
+    system_lib_path = "/usr/lib64:/usr/lib"  # Replace this if your libcurl location is different
     os.environ["LD_LIBRARY_PATH"] = f"{system_lib_path}:" + os.environ.get("LD_LIBRARY_PATH", "")
     callback()
-    os.environ["LD_LIBRARY_PATH"] = os.environ.get("LD_LIBRARY_PATH", "").replace("/usr/lib:", "")
+    os.environ["LD_LIBRARY_PATH"] = os.environ.get("LD_LIBRARY_PATH", "").replace("/usr/lib64:/usr/lib:", "")


### PR DESCRIPTION
Should fix
```/usr/lib/git-core/git-remote-https: symbol lookup error: /usr/lib/git-core/git-remote-https: undefined symbol: curl_global_sslset```
idk if it'll work on all systems: can't test rn