### PR TITLE
fix: allow query params in ftp file protocol

### DIFF
--- a/include/url_parser.h
+++ b/include/url_parser.h
@@ -91,13 +91,20 @@ static const std::string UrlFromPath(const std::string baseAddress, const std::s
 
 static const std::string PathFromUrl(const std::string& path)
 {
+    // Remove query parameters for file path
+    std::string cleanPath = path;
+    size_t queryPos = cleanPath.find('?');
+    if (queryPos != std::string::npos) {
+        cleanPath = cleanPath.substr(0, queryPos);
+    }
+
     #if defined(__linux__) || defined(__APPLE__)
     {
-        return "/" + UrlDecode(path);
+        return "/" + UrlDecode(cleanPath);
     }
     #elif _WIN32
     {
-        return UrlDecode(path);
+        return UrlDecode(cleanPath);
     }
     #endif
 }

--- a/preload/src/unzip.cc
+++ b/preload/src/unzip.cc
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <direct.h>
+#include <winsock2.h>
 #include <windows.h> 
 #include <minizip/unzip.h>
 #include <iostream>


### PR DESCRIPTION
Filters out query params from file protocol urls  
Also added winsock2 include because of this warning `warning: #warning Please include winsock2.h before windows.h`