### PR TITLE
nix: add fetcherVersion to  pnpm.fetchDeps

### DIFF
--- a/nix/assets.nix
+++ b/nix/assets.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
   pnpmDeps = pnpm.fetchDeps {
     inherit src version pname;
     hash = "sha256-nDSltpFQRM9loVuDour4OrRdN22/A7MkZTGAtL0x7rU=";
+    fetcherVersion = 9;
   };
   nativeBuildInputs = [
     pnpm.configHook

--- a/nix/typescript/shims.nix
+++ b/nix/typescript/shims.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
     inherit src version pname;
     #TODO: automatic hash update
     hash = "sha256-LofHepVz6CjbAXkUwwNFVzlbmPq+g/gJvkBka9I/gHo=";
+    fetcherVersion = 9;
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
```nix
  pnpmDeps = pnpm.fetchDeps {
    inherit src version pname;
    hash = "sha256-nDSltpFQRM9loVuDour4OrRdN22/A7MkZTGAtL0x7rU=";
    fetcherVersion = 9;
  };
```

`pnpm.fetchDeps` requires the argument `fetcherVersion` as of https://github.com/NixOS/nixpkgs/pull/422975