### PR TITLE
fix: plugin updater merge instead of replacing

### DIFF
--- a/assets/core/plugins/plugin_updater.py
+++ b/assets/core/plugins/plugin_updater.py
@@ -116,10 +116,12 @@ class PluginUpdater:
             extracted_folder = extracted_dirs[0]
             target_folder = Path(self.plugins_path) / name
 
-            # Replace existing plugin folder
-            if target_folder.exists():
-                shutil.rmtree(target_folder)
-            extracted_folder.rename(target_folder)
+            # Merge the extracted folder with the target folder
+            if not target_folder.exists():
+                target_folder.mkdir(parents=True)
+            shutil.copytree(extracted_folder, target_folder, dirs_exist_ok=True)
+            # Cleanup
+            shutil.rmtree(extracted_folder)
 
             logger.log(f"Plugin {name} installed successfully to {target_folder}")
 


### PR DESCRIPTION
Currently the updater deletes the existing plugin, replacing it with the updated version.
You've said in Discord that it shouldn't outright remove anything, so I've made this merge the directories instead to follow that

Closes #466

https://github.com/user-attachments/assets/5fe8f38a-dee1-4a9b-b0ab-2a6b1f92ffe9

