### PR TITLE
Ensure git exists in Steam's FHSEnv/Various fixes and additions for the Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 # Special thanks to @Sk7Str1p3, @mourogurt, @kaeeraa, @mctrxw for help with this flake and packages
 {
   description = ''
-    Millennium - an open-source low-code modding framework to create, 
+    Millennium - an open-source low-code modding framework to create,
     manage and use themes/plugins for the desktop Steam Client
   '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,9 @@
           millennium = pkgs.callPackage ./nix/python/millennium.nix { };
           core-utils = pkgs.callPackage ./nix/python/core-utils.nix { };
         };
+        # basic script to update pnpm hashes in the shims and assets package definitions
+        # usage: nix run .#update-pnpm-hashes
+        update-pnpm-hashes = pkgs.callPackage ./nix/update.nix { };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
       overlays.default = final: prev: rec {
         inherit (self.packages."x86_64-linux") millennium;
         steam-millennium = final.steam.override (prev: {
+          extraPkgs = pkgs: [ pkgs.git ];
           extraProfile =
             ''
               export LD_LIBRARY_PATH="${millennium}/lib/millenium/''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"

--- a/nix/millennium.nix
+++ b/nix/millennium.nix
@@ -86,7 +86,7 @@ pkgsi686Linux.stdenv.mkDerivation {
 
     mkdir -p $out/lib/millennium
     cp libmillennium_x86.so $out/lib/millennium
-    
+
     runHook postInstall
   '';
   NIX_CFLAGS_COMPILE = [

--- a/nix/python/core-utils.nix
+++ b/nix/python/core-utils.nix
@@ -1,4 +1,4 @@
-{pkgs}: 
+{ pkgs }:
 pkgs.python311Packages.buildPythonPackage {
   pname = "millennium-core-utils";
   version = "git";

--- a/nix/python/millennium.nix
+++ b/nix/python/millennium.nix
@@ -1,4 +1,4 @@
-{pkgs}: 
+{ pkgs }:
 pkgs.python311Packages.buildPythonPackage {
   pname = "millennium";
   version = "git";

--- a/nix/typescript/shims.nix
+++ b/nix/typescript/shims.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   pnpmDeps = pnpm.fetchDeps {
     inherit src version pname;
     #TODO: automatic hash update
-    hash = "sha256-LofHepVz6CjbAXkUwwNFVzlbmPq+g/gJvkBka9I/gHo=";
+    hash = "sha256-1cqsNIQnrVAe18FC8D6mnptH+gp4B5+hyGF9lGn0OE0=";
     fetcherVersion = 2;
   };
 

--- a/nix/update.nix
+++ b/nix/update.nix
@@ -1,0 +1,9 @@
+{
+  lib,
+  writeShellScriptBin,
+  nix-update,
+}:
+writeShellScriptBin "update-pnpm-hashes" ''
+  ${lib.getExe nix-update} --version skip --flake assets
+  ${lib.getExe nix-update} --version skip --flake shims
+''

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{pkgs ? import <nixpkgs>}:
+{
+  pkgs ? import <nixpkgs>,
+}:
 with pkgs;
 
 mkShell {


### PR DESCRIPTION
So, originally this was just going to be a pr to add git to steam's `extraPkgs` because its not included by default and if the user doesn't have it installed (or steam is launched from somewhere that doesn't have git included in the `PATH`, like a systemd service), GitPython freaks out because it can't find the `git` executable and Millennium's core plugin fails to load.

As I was adding that, a few other small things jumped out at me, (ie, the pnpmDeps hash for the SDK was out of date since the sdk has been updated).

I also saw the TODO for automating the pnpmDeps hashes, while I'm not sure the best/easiest way to fully automate it, I put together a (probably janky) script that *should* update both hashes just by running `nix run .#update-pnpm-hashes` although `nix-update` does seem rather inconsistent so YMMV.

Each of the various changes has its own commit, if anything needs to be changed or removed LMK.