### PR TITLE
feat: Add atomic distribution support

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Set the project name and language

--- a/scripts/posix/start.sh
+++ b/scripts/posix/start.sh
@@ -10,12 +10,12 @@ export OPENSSL_CONF=/dev/null
 
 # Only set LD_PRELOAD if MILLENNIUM_RUNTIME_PATH is not set
 if [ -z "${MILLENNIUM_RUNTIME_PATH}" ]; then
-    export LD_PRELOAD="/usr/lib/millennium/libmillennium_x86.so${LD_PRELOAD:+:$LD_PRELOAD}" # preload Millennium into Steam
+    export LD_PRELOAD="/usr/lib/millennium/libmillennium_x86.so:/usr/local/lib/millennium/libmillennium_x86.so${LD_PRELOAD:+:$LD_PRELOAD}" # preload Millennium into Steam
 else
     export LD_PRELOAD="${MILLENNIUM_RUNTIME_PATH}${LD_PRELOAD:+:$LD_PRELOAD}" # use custom LD_PRELOAD if set
 fi
 
-export LD_LIBRARY_PATH="/usr/lib/millennium/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="/usr/lib/millennium/:/usr/local/lib/millennium/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # Millennium hooks __libc_start_main to initialize itself, which is a function that is called before main. 
 # Besides that, Millennium does not alter Steam memory and runs completely disjoint.

--- a/src/sys/env.cc
+++ b/src/sys/env.cc
@@ -41,6 +41,7 @@
 #include <stdlib.h>
 #include <string>
 #include <unistd.h>
+#include <filesystem>
 
 #if defined(__linux__) || defined(__APPLE__)
 extern char** environ;
@@ -157,7 +158,11 @@ const void SetupEnvironmentVariables()
 #ifdef _NIX_OS
     const auto shimsPath = fmt::format("{}/share/millennium/shims", __NIX_SHIMS_PATH);
 #else
-    const auto shimsPath = "/usr/share/millennium/shims";
+    const char * shimsPath;
+    if (std::filesystem::exists("/usr/local/bin/millennium"))
+        shimsPath = "/usr/local/share/millennium/shims";
+    else
+        shimsPath = "/usr/share/millennium/shims";
 #endif
 #elif __APPLE__
     const auto shimsPath = "/usr/local/share/millennium/shims";
@@ -174,7 +179,11 @@ const void SetupEnvironmentVariables()
 #ifdef _NIX_OS
     const auto assetsPath = fmt::format("{}/share/millennium/assets", __NIX_ASSETS_PATH);
 #else
-    const auto assetsPath = "/usr/share/millennium/assets";
+    const char * assetsPath;
+    if (std::filesystem::exists("/usr/local/bin/millennium"))
+        assetsPath = "/usr/local/share/millennium/assets";
+    else
+        assetsPath = "/usr/share/millennium/assets";
 #endif
 #elif __APPLE__
     const auto assetsPath = "/usr/local/share/millennium/assets";
@@ -208,6 +217,11 @@ const void SetupEnvironmentVariables()
     }
 
     const std::string customLdPreload = GetEnv("MILLENNIUM_RUNTIME_PATH");
+    const char * millenium_runtime_path;
+    if (std::filesystem::exists("/usr/local/bin/millennium"))
+        millenium_runtime_path = "/usr/local/lib/millennium/libmillennium_x86.so";
+    else
+        millenium_runtime_path = "/usr/lib/millennium/libmillennium_x86.so";
 
     std::map<std::string, std::string> environment_unix = {
         {"OPENSSL_CONF", "/dev/null"},
@@ -215,7 +229,7 @@ const void SetupEnvironmentVariables()
 #ifdef _NIX_OS
                                                           fmt::format("{}/lib/millennium/libMillennium_x86.so", __NIX_SELF_PATH)
 #else
-                                                          "/usr/lib/millennium/libmillennium_x86.so"
+                                                          millenium_runtime_path
 #endif
         },
 


### PR DESCRIPTION
This PR adds support for Linux systems where /usr is read only by utilizing /usr/local which is writable on Universal Blue based distributions. The PR has been tested on Bazzite. List of changes:

* `cli/CMakeLists.txt`: C++ standard has been upgraded from C++ 11 to C++ 17. This is necessary to use std::filesystem.
* `cli/src/main.cc`: new logic has been added to check if /usr/bin/steam is modifiable. If it is not, an attempt is made to create a copy at `/usr/local/bin`. If it is successful, patching is performed in `/usr/local/bin/steam`. If it fails, millennium exits.
* `scripts/install.sh`: Script checks if /usr/bin is writable, if not it /usr/local/bin is checked. If that also fails, script exits.
* `scripts/posix/start.sh`: .so file is searched in both /usr/local/bin and /usr/bin. Lack of file in either directory is harmless.
* `src/sys/env.cc`: If `/usr/local/bin/millennium` exists, /usr/ is changed to /usr/local (done 3 times)

Todo / Caveats:
* /usr/local is not writable on some distributions ie bootc based CentOS. I did not know this when starting working on this. ~/.local/bin can be used instead.
* check_patch_status() in millennium cli does not check for /usr/local.
* Bazzite uses a custom script `/usr/bin/bazzite-steam` to launch Steam on desktop. This needs to be changed to `/usr/bin/local/steam` or simply `steam` which is not prevented by read only /usr.