### PR TITLE
feat(sdk): add plugin localization

### DIFF
--- a/src/typescript/sdk/src/api.ts
+++ b/src/typescript/sdk/src/api.ts
@@ -1,2 +1,3 @@
 export * from './sharedjscontext/index';
 export * from './millennium-api';
+export * from './localization';

--- a/src/typescript/sdk/src/index.ts
+++ b/src/typescript/sdk/src/index.ts
@@ -30,9 +30,10 @@ class Bootstrap {
 	async loadMillennium() {
 		const steambrewClientModule = await import('./sharedjscontext/index');
 		const millenniumApiModule = await import('./millennium-api');
+		const localizationModule = await import('./localization');
 
 		/** Set Auth Token */
-		Object.assign((window.MILLENNIUM_API ??= {}), steambrewClientModule, millenniumApiModule);
+		Object.assign((window.MILLENNIUM_API ??= {}), steambrewClientModule, millenniumApiModule, localizationModule);
 
 		/** send some diagnostics about the state of the frontend. it gets forwards to the MEP */
 		const apiEntries = Object.entries(window.MILLENNIUM_API);
@@ -119,8 +120,9 @@ class Bootstrap {
 	async startBrowser(enabledPlugins?: string[], legacyShimList?: string[], ctxShimList?: string[], _ftpBasePath?: string) {
 		this.init('');
 		const millenniumApiModule = await import('./millennium-api');
+		const localizationModule = await import('./localization');
 
-		window.MILLENNIUM_API = millenniumApiModule;
+		window.MILLENNIUM_API = { ...millenniumApiModule, ...localizationModule };
 
 		const browserUtils = await import('./browser-init');
 		await browserUtils.appendAccentColor();

--- a/src/typescript/sdk/src/localization.ts
+++ b/src/typescript/sdk/src/localization.ts
@@ -164,7 +164,7 @@ export function useLocalization(pluginName?: string): Localization {
  *
  * @example
  * ```typescript
- * // plugin.json: "dependencies": ["some-plugin"]
+ * // millennium.toml: dependencies = ["some-plugin"]
  * import russian from '../locales/russian.json';
  * contributeLocale('some-plugin', 'russian', russian);
  * ```
@@ -178,7 +178,7 @@ export function contributeLocale(a: string, b: string, c: string | Record<string
 
 	/** a plugin translates what it declares and nothing else */
 	if (caller && !(window.MILLENNIUM_PLUGIN_DEPENDENCIES[caller] ?? []).includes(targetPlugin)) {
-		console.error(`[Millennium] '${caller}' tried to translate '${targetPlugin}', which it doesn't declare in its plugin.json.`);
+		console.error(`[Millennium] '${caller}' tried to translate '${targetPlugin}', which it doesn't declare in its manifest.`);
 		return;
 	}
 

--- a/src/typescript/sdk/src/localization.ts
+++ b/src/typescript/sdk/src/localization.ts
@@ -1,0 +1,205 @@
+/**
+ * ==================================================
+ *   _____ _ _ _             _
+ *  |     |_| | |___ ___ ___|_|_ _ _____
+ *  | | | | | | | -_|   |   | | | |     |
+ *  |_|_|_|_|_|_|___|_|_|_|_|_|___|_|_|_|
+ *
+ * ==================================================
+ *
+ * Copyright (c) 2026 Project Millennium
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Plugin localization.
+ *
+ * A plugin ships a `locales` folder with one JSON file per language, named after
+ * Steam's API language code (english.json, russian.json, ...). The build embeds
+ * them, so nothing is fetched at runtime and the strings are known offline.
+ *
+ * Anyone can also translate a plugin they don't own: a translation plugin calls
+ * `contributeLocale()` with the target's name, and the target picks the strings up
+ * without knowing anything about it. Declaring the target in the translation
+ * plugin's `requires` makes Millennium load it after the target and tell the user
+ * when it's missing.
+ */
+
+const LOCALE_UPDATED_EVENT = 'millennium-locale-updated';
+const FALLBACK_LANGUAGE = 'english';
+
+declare global {
+	interface Window {
+		/** Strings embedded from each plugin's own `locales` folder at build time. */
+		MILLENNIUM_PLUGIN_LOCALES: Record<string, Record<string, Record<string, string>>>;
+		/** Strings contributed for other plugins, which take precedence over their own. */
+		MILLENNIUM_LOCALE_OVERRIDES: Record<string, Record<string, Record<string, string>>>;
+		/** The plugins each plugin declares in its manifest, embedded at build time. */
+		MILLENNIUM_PLUGIN_DEPENDENCIES: Record<string, string[]>;
+	}
+}
+
+window.MILLENNIUM_PLUGIN_LOCALES ??= {};
+window.MILLENNIUM_LOCALE_OVERRIDES ??= {};
+window.MILLENNIUM_PLUGIN_DEPENDENCIES ??= {};
+
+/** Steam's language for this session. Resolved once, English until it arrives. */
+let _language = FALLBACK_LANGUAGE;
+
+const _resolveLanguage = (async () => {
+	try {
+		const language = await (window as any).SteamClient?.Settings?.GetCurrentLanguage?.();
+		if (typeof language === 'string' && language.length) {
+			_language = language;
+			window.dispatchEvent(new CustomEvent(LOCALE_UPDATED_EVENT, { detail: { language } }));
+		}
+	} catch {
+		/* keep the fallback, a missing language is not worth failing over */
+	}
+})();
+
+/** Replaces {0}, {1}, ... with the given arguments, leaving unmatched ones alone. */
+const format = (template: string, args: string[]): string => template.replace(/{(\d+)}/g, (match, index) => args[index] ?? match);
+
+export interface Localization {
+	/** Translate a key, formatting any {0}-style placeholders with the extra arguments. */
+	(key: string, ...args: string[]): string;
+	/** The language these strings resolve against. */
+	readonly language: string;
+}
+
+const _lookup = (pluginName: string, key: string): string | undefined => {
+	const overrides = window.MILLENNIUM_LOCALE_OVERRIDES[pluginName] ?? {};
+	const own = window.MILLENNIUM_PLUGIN_LOCALES[pluginName] ?? {};
+
+	/** a contributed translation wins over the plugin's own strings, and both fall
+	    back to English so a partial translation only affects the keys it covers */
+	return overrides[_language]?.[key] ?? own[_language]?.[key] ?? overrides[FALLBACK_LANGUAGE]?.[key] ?? own[FALLBACK_LANGUAGE]?.[key];
+};
+
+/**
+ * @brief Get a plugin's translations outside of React.
+ *
+ * @example
+ * ```typescript
+ * const t = getLocalization();
+ * console.log(t('greeting', 'world'));
+ * ```
+ */
+export function getLocalization(): Localization;
+export function getLocalization(pluginName: string): Localization;
+export function getLocalization(pluginName?: string): Localization {
+	const name = pluginName ?? '';
+
+	const translate = ((key: string, ...args: string[]) => {
+		const value = _lookup(name, key);
+		if (value === undefined) return key;
+		return args.length ? format(value, args) : value;
+	}) as Localization;
+
+	Object.defineProperty(translate, 'language', { get: () => _language });
+	return translate;
+}
+
+/**
+ * @brief Get a plugin's translations in a component, re-rendering when they change.
+ *
+ * The language arrives asynchronously and translations can be contributed by other
+ * plugins at any point, so components read strings through this hook rather than
+ * capturing them once.
+ *
+ * @example
+ * ```typescript
+ * const t = useLocalization();
+ * return <Field label={t('settingsTitle')} />;
+ * ```
+ */
+export function useLocalization(): Localization;
+export function useLocalization(pluginName: string): Localization;
+export function useLocalization(pluginName?: string): Localization {
+	const React = (window as any).SP_REACT;
+	const name = pluginName ?? '';
+	const [, setRevision] = React.useState(0);
+
+	React.useEffect(() => {
+		const onLocaleUpdated = (event: Event) => {
+			const target = (event as CustomEvent)?.detail?.plugin;
+			if (target === undefined || target === name) setRevision((revision: number) => revision + 1);
+		};
+
+		window.addEventListener(LOCALE_UPDATED_EVENT, onLocaleUpdated);
+		return () => window.removeEventListener(LOCALE_UPDATED_EVENT, onLocaleUpdated);
+	}, [name]);
+
+	return React.useMemo(() => getLocalization(name), [name, _language]);
+}
+
+/**
+ * @brief Translate another plugin, without that plugin doing anything for it.
+ *
+ * Only plugins named in this plugin's own "requires" or "dependencies" can be
+ * translated, so the manifest says what a plugin reaches into and Millennium can tell
+ * the user what a translation is for before they install it.
+ *
+ * The strings replace the target's own for the given language, key by key. Anything
+ * left out keeps whatever the target already had, so a partial translation is fine.
+ * If the target isn't installed the strings simply sit unused.
+ *
+ * @example
+ * ```typescript
+ * // plugin.json: "dependencies": ["some-plugin"]
+ * import russian from '../locales/russian.json';
+ * contributeLocale('some-plugin', 'russian', russian);
+ * ```
+ */
+export function contributeLocale(targetPlugin: string, language: string, strings: Record<string, string>): void;
+export function contributeLocale(pluginName: string, targetPlugin: string, language: string, strings: Record<string, string>): void;
+export function contributeLocale(a: string, b: string, c: string | Record<string, string>, d?: Record<string, string>): void {
+	const [caller, targetPlugin, language, strings] = d !== undefined ? [a, b, c as string, d] : ['', a, b, c as Record<string, string>];
+
+	if (!targetPlugin || !language || typeof strings !== 'object' || strings === null) return;
+
+	/** a plugin translates what it declares and nothing else */
+	if (caller && !(window.MILLENNIUM_PLUGIN_DEPENDENCIES[caller] ?? []).includes(targetPlugin)) {
+		console.error(`[Millennium] '${caller}' tried to translate '${targetPlugin}', which it doesn't declare in its plugin.json.`);
+		return;
+	}
+
+	const target = (window.MILLENNIUM_LOCALE_OVERRIDES[targetPlugin] ??= {});
+	target[language] = { ...target[language], ...strings };
+
+	window.dispatchEvent(new CustomEvent(LOCALE_UPDATED_EVENT, { detail: { plugin: targetPlugin, language } }));
+}
+
+/**
+ * @brief The languages a plugin can be displayed in, its own and contributed ones.
+ */
+export function getAvailableLanguages(): string[];
+export function getAvailableLanguages(pluginName: string): string[];
+export function getAvailableLanguages(pluginName?: string): string[] {
+	const name = pluginName ?? '';
+	const own = Object.keys(window.MILLENNIUM_PLUGIN_LOCALES[name] ?? {});
+	const contributed = Object.keys(window.MILLENNIUM_LOCALE_OVERRIDES[name] ?? {});
+
+	return [...new Set([...own, ...contributed])];
+}
+
+/** Resolves once Steam's language is known, for callers that need it up front. */
+export const localizationReady: Promise<void> = _resolveLanguage;

--- a/src/typescript/ttc/src/transpiler.ts
+++ b/src/typescript/ttc/src/transpiler.ts
@@ -82,6 +82,8 @@ const buildPluginWrapper = template.statements({
 	const pluginName = %%pluginName%%;
 	(window.PLUGIN_LIST ||= {})[pluginName] ||= {};
 	window.MILLENNIUM_SIDEBAR_NAVIGATION_PANELS ||= {};
+	(window.MILLENNIUM_PLUGIN_LOCALES ||= {})[pluginName] = %%locales%%;
+	(window.MILLENNIUM_PLUGIN_DEPENDENCIES ||= {})[pluginName] = %%dependencies%%;
 
 	let PluginEntryPointMain = function () {
 		%%chunkBody%%
@@ -109,6 +111,50 @@ const buildPluginWrapper = template.statements({
 	})();
 `);
 
+/**
+ * Reads the plugin's `locales` folder, if it has one. Each file is named after the
+ * Steam API language code it holds, e.g. locales/english.json. They are embedded in
+ * the bundle so nothing has to be fetched at runtime.
+ */
+function readPluginLocales(): Record<string, Record<string, string>> {
+	const localesDir = path.join(process.cwd(), 'locales');
+	const locales: Record<string, Record<string, string>> = {};
+
+	if (!fs.existsSync(localesDir)) {
+		return locales;
+	}
+
+	for (const file of fs.readdirSync(localesDir)) {
+		if (!file.endsWith('.json')) continue;
+
+		try {
+			const contents = JSON.parse(fs.readFileSync(path.join(localesDir, file), 'utf-8'));
+			if (contents && typeof contents === 'object' && !Array.isArray(contents)) {
+				locales[path.basename(file, '.json')] = contents;
+			}
+		} catch (error) {
+			Logger.warn(`Skipping locale file '${file}': ${(error as Error).message}`);
+		}
+	}
+	return locales;
+}
+
+/**
+ * Reads the plugin names this plugin declares in "requires" and "dependencies".
+ * A plugin can only contribute translations to plugins it declares, so the manifest
+ * stays the source of truth for what it reaches into.
+ */
+function readDeclaredDependencies(): string[] {
+	try {
+		const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'plugin.json'), 'utf-8'));
+		const declared = [...(manifest?.requires ?? []), ...(manifest?.dependencies ?? [])];
+
+		return declared.filter((spec: unknown): spec is string => typeof spec === 'string').map((spec: string) => spec.split('@')[0]);
+	} catch {
+		return [];
+	}
+}
+
 function insertMillennium(target: BuildTarget, props: TranspilerProps): InputPluginOption {
 	return {
 		name: 'insert-millennium',
@@ -117,6 +163,8 @@ function insertMillennium(target: BuildTarget, props: TranspilerProps): InputPlu
 			const wrapped = buildPluginWrapper({
 				isClient: t.booleanLiteral(target === BuildTarget.Plugin),
 				pluginName: t.stringLiteral(props.pluginName),
+				locales: t.valueToNode(readPluginLocales()),
+				dependencies: t.valueToNode(readDeclaredDependencies()),
 				chunkBody: chunkAst.program.body,
 			});
 
@@ -232,6 +280,10 @@ function pluginNameInjections(ns: string): Transform[] {
 		{ type: 'inject_arg', match: [ns, 'pluginConfig', 'getAll'], arg: 'pluginName' },
 		{ type: 'inject_arg', match: [ns, 'usePluginConfig'], arg: 'pluginName' },
 		{ type: 'inject_arg', match: [ns, 'subscribePluginConfig'], arg: 'pluginName' },
+		{ type: 'inject_arg', match: [ns, 'useLocalization'], arg: 'pluginName' },
+		{ type: 'inject_arg', match: [ns, 'getLocalization'], arg: 'pluginName' },
+		{ type: 'inject_arg', match: [ns, 'getAvailableLanguages'], arg: 'pluginName' },
+		{ type: 'inject_arg', match: [ns, 'contributeLocale'], arg: 'pluginName' },
 	];
 }
 

--- a/src/typescript/ttc/src/transpiler.ts
+++ b/src/typescript/ttc/src/transpiler.ts
@@ -82,8 +82,6 @@ const buildPluginWrapper = template.statements({
 	const pluginName = %%pluginName%%;
 	(window.PLUGIN_LIST ||= {})[pluginName] ||= {};
 	window.MILLENNIUM_SIDEBAR_NAVIGATION_PANELS ||= {};
-	(window.MILLENNIUM_PLUGIN_LOCALES ||= {})[pluginName] = %%locales%%;
-	(window.MILLENNIUM_PLUGIN_DEPENDENCIES ||= {})[pluginName] = %%dependencies%%;
 
 	let PluginEntryPointMain = function () {
 		%%chunkBody%%
@@ -111,50 +109,6 @@ const buildPluginWrapper = template.statements({
 	})();
 `);
 
-/**
- * Reads the plugin's `locales` folder, if it has one. Each file is named after the
- * Steam API language code it holds, e.g. locales/english.json. They are embedded in
- * the bundle so nothing has to be fetched at runtime.
- */
-function readPluginLocales(): Record<string, Record<string, string>> {
-	const localesDir = path.join(process.cwd(), 'locales');
-	const locales: Record<string, Record<string, string>> = {};
-
-	if (!fs.existsSync(localesDir)) {
-		return locales;
-	}
-
-	for (const file of fs.readdirSync(localesDir)) {
-		if (!file.endsWith('.json')) continue;
-
-		try {
-			const contents = JSON.parse(fs.readFileSync(path.join(localesDir, file), 'utf-8'));
-			if (contents && typeof contents === 'object' && !Array.isArray(contents)) {
-				locales[path.basename(file, '.json')] = contents;
-			}
-		} catch (error) {
-			Logger.warn(`Skipping locale file '${file}': ${(error as Error).message}`);
-		}
-	}
-	return locales;
-}
-
-/**
- * Reads the plugin names this plugin declares in "requires" and "dependencies".
- * A plugin can only contribute translations to plugins it declares, so the manifest
- * stays the source of truth for what it reaches into.
- */
-function readDeclaredDependencies(): string[] {
-	try {
-		const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'plugin.json'), 'utf-8'));
-		const declared = [...(manifest?.requires ?? []), ...(manifest?.dependencies ?? [])];
-
-		return declared.filter((spec: unknown): spec is string => typeof spec === 'string').map((spec: string) => spec.split('@')[0]);
-	} catch {
-		return [];
-	}
-}
-
 function insertMillennium(target: BuildTarget, props: TranspilerProps): InputPluginOption {
 	return {
 		name: 'insert-millennium',
@@ -163,8 +117,6 @@ function insertMillennium(target: BuildTarget, props: TranspilerProps): InputPlu
 			const wrapped = buildPluginWrapper({
 				isClient: t.booleanLiteral(target === BuildTarget.Plugin),
 				pluginName: t.stringLiteral(props.pluginName),
-				locales: t.valueToNode(readPluginLocales()),
-				dependencies: t.valueToNode(readDeclaredDependencies()),
 				chunkBody: chunkAst.program.body,
 			});
 
@@ -280,10 +232,6 @@ function pluginNameInjections(ns: string): Transform[] {
 		{ type: 'inject_arg', match: [ns, 'pluginConfig', 'getAll'], arg: 'pluginName' },
 		{ type: 'inject_arg', match: [ns, 'usePluginConfig'], arg: 'pluginName' },
 		{ type: 'inject_arg', match: [ns, 'subscribePluginConfig'], arg: 'pluginName' },
-		{ type: 'inject_arg', match: [ns, 'useLocalization'], arg: 'pluginName' },
-		{ type: 'inject_arg', match: [ns, 'getLocalization'], arg: 'pluginName' },
-		{ type: 'inject_arg', match: [ns, 'getAvailableLanguages'], arg: 'pluginName' },
-		{ type: 'inject_arg', match: [ns, 'contributeLocale'], arg: 'pluginName' },
 	];
 }
 

--- a/starlight/src/bundler/js.rs
+++ b/starlight/src/bundler/js.rs
@@ -70,6 +70,38 @@ pub enum BundleTarget {
     Webkit,
 }
 
+/// Reads the plugin's `locales` folder, if it has one. Each file is named after the
+/// Steam API language code it holds, e.g. locales/english.json. They are embedded in
+/// the bundle so nothing has to be fetched at runtime.
+fn read_locales(config_dir: &Path) -> String {
+    let mut locales = serde_json::Map::new();
+    let Ok(entries) = std::fs::read_dir(config_dir.join("locales")) else {
+        return "{}".to_string();
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        let Some(language) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+
+        match std::fs::read_to_string(&path)
+            .map(|text| serde_json::from_str::<serde_json::Value>(&text))
+        {
+            Ok(Ok(value)) if value.is_object() => {
+                locales.insert(language.to_string(), value);
+            }
+            _ => crate::log::warn(&format!("skipping locale file '{}'", path.display())),
+        }
+    }
+
+    serde_json::Value::Object(locales).to_string()
+}
+
 pub fn bundle(
     entry: &str,
     config_dir: &Path,
@@ -81,6 +113,7 @@ pub fn bundle(
     inspect: &crate::config::InspectConfig,
     outro: Option<String>,
     lua_ffi_names: &[String],
+    declared_dependencies: &[String],
 ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
     let rt = tokio::runtime::Runtime::new()
         .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {}", e))?;
@@ -95,6 +128,7 @@ pub fn bundle(
         inspect,
         outro,
         lua_ffi_names,
+        declared_dependencies,
     ))
 }
 
@@ -109,6 +143,7 @@ async fn async_bundle(
     inspect: &crate::config::InspectConfig,
     outro: Option<String>,
     lua_ffi_names: &[String],
+    declared_dependencies: &[String],
 ) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
     let entry_path = if Path::new(entry).is_absolute() {
         entry.to_string()
@@ -217,6 +252,8 @@ async fn async_bundle(
     let transformed = apply_transforms(&raw_js, &ia, rn, Some(&CONSOLE_HOOK), sm.as_ref());
 
     let is_client = matches!(target, BundleTarget::Frontend);
+    let dependencies_json =
+        serde_json::to_string(declared_dependencies).unwrap_or_else(|_| "[]".to_string());
     let (wrapped, iife_line_offset, iife_col_offset) = wrap(
         &transformed,
         plugin_name,
@@ -224,6 +261,8 @@ async fn async_bundle(
         source_map_url,
         inspect,
         lua_ffi_names,
+        &read_locales(config_dir),
+        &dependencies_json,
     );
 
     let final_js = if mode == BuildMode::Release {
@@ -270,4 +309,41 @@ fn shift_sourcemap(sm: &sourcemap::SourceMap, line_offset: u32, col_offset: u32)
     let mut out = Vec::new();
     let _ = shifted.to_writer(&mut out);
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_locales;
+
+    #[test]
+    fn reads_locale_files_and_ignores_the_rest() {
+        let dir = std::env::temp_dir().join("starlight_locales_test");
+        let locales = dir.join("locales");
+        std::fs::create_dir_all(&locales).unwrap();
+        std::fs::write(locales.join("english.json"), r#"{"greeting":"Hello"}"#).unwrap();
+        std::fs::write(locales.join("russian.json"), r#"{"greeting":"Привет"}"#).unwrap();
+        std::fs::write(locales.join("notes.txt"), "ignored").unwrap();
+
+        let json = read_locales(&dir);
+
+        assert!(
+            json.contains(r#""english":{"greeting":"Hello"}"#),
+            "got {json}"
+        );
+        assert!(json.contains("russian"), "got {json}");
+        assert!(!json.contains("notes"), "got {json}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn plugin_without_a_locales_folder_reads_as_empty() {
+        let dir = std::env::temp_dir().join("starlight_locales_missing");
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+
+        assert_eq!(read_locales(&dir), "{}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/starlight/src/bundler/shim.js
+++ b/starlight/src/bundler/shim.js
@@ -2,6 +2,8 @@ const MILLENNIUM_IS_CLIENT_MODULE = __IS_CLIENT__;
 const pluginName = __PLUGIN_NAME__;
 (window.PLUGIN_LIST ||= {})[pluginName] ||= {};
 window.MILLENNIUM_SIDEBAR_NAVIGATION_PANELS ||= {};
+(window.MILLENNIUM_PLUGIN_LOCALES ||= {})[pluginName] = __LOCALES__;
+(window.MILLENNIUM_PLUGIN_DEPENDENCIES ||= {})[pluginName] = __DEPENDENCIES__;
 __FFI_STUBS__;
 __FRONTEND_PROXY__;
 var __millennium_plugin_console__ = (function () {

--- a/starlight/src/bundler/transforms.rs
+++ b/starlight/src/bundler/transforms.rs
@@ -724,6 +724,22 @@ macro_rules! inject_args_for_ns {
                 path: &[$ns, "subscribePluginConfig"],
                 arg: "pluginName",
             },
+            InjectArg {
+                path: &[$ns, "useLocalization"],
+                arg: "pluginName",
+            },
+            InjectArg {
+                path: &[$ns, "getLocalization"],
+                arg: "pluginName",
+            },
+            InjectArg {
+                path: &[$ns, "getAvailableLanguages"],
+                arg: "pluginName",
+            },
+            InjectArg {
+                path: &[$ns, "contributeLocale"],
+                arg: "pluginName",
+            },
         ]
     };
 }

--- a/starlight/src/bundler/wrapper.rs
+++ b/starlight/src/bundler/wrapper.rs
@@ -40,6 +40,8 @@ pub fn wrap(
     source_map_url: Option<&str>,
     inspect: &crate::config::InspectConfig,
     lua_ffi_names: &[String],
+    locales_json: &str,
+    dependencies_json: &str,
 ) -> (String, u32, u32) {
     let iife_expr = extract_iife(strip_sourcemap(bundle_js).trim_end());
 
@@ -82,6 +84,8 @@ pub fn wrap(
     let shim = SHIM_JS
         .replace("__IS_CLIENT__", if is_client { "true" } else { "false" })
         .replace("__PLUGIN_NAME__", &plugin_name_json)
+        .replace("__LOCALES__", locales_json)
+        .replace("__DEPENDENCIES__", dependencies_json)
         .replace("__FFI_STUBS__;", &ffi_stubs)
         .replace("__FRONTEND_PROXY__;", &frontend_proxy)
         .replace("__INSPECT_POLYFILL__;", INSPECT_POLYFILL_JS)
@@ -149,6 +153,8 @@ mod tests {
             Some("file:///test.map"),
             &default_inspect(),
             &[],
+            "{}",
+            "[]",
         );
         assert!(
             out.contains("//# sourceMappingURL=file:///test.map"),
@@ -158,9 +164,62 @@ mod tests {
     }
 
     #[test]
+    fn locales_and_dependencies_are_embedded() {
+        let bundle = "(function() { return {}; })()";
+        let (out, _, _) = wrap(
+            bundle,
+            "test",
+            true,
+            None,
+            &default_inspect(),
+            &[],
+            r#"{"english":{"greeting":"Hello"}}"#,
+            r#"["some-plugin"]"#,
+        );
+
+        assert!(
+            out.contains(r#"(window.MILLENNIUM_PLUGIN_LOCALES ||= {})[pluginName] = {"english":{"greeting":"Hello"}};"#),
+            "locales missing from the wrapper"
+        );
+        assert!(
+            out.contains(
+                r#"(window.MILLENNIUM_PLUGIN_DEPENDENCIES ||= {})[pluginName] = ["some-plugin"];"#
+            ),
+            "declared dependencies missing from the wrapper"
+        );
+    }
+
+    #[test]
+    fn plugin_without_locales_embeds_empty_objects() {
+        let bundle = "(function() { return {}; })()";
+        let (out, _, _) = wrap(
+            bundle,
+            "test",
+            true,
+            None,
+            &default_inspect(),
+            &[],
+            "{}",
+            "[]",
+        );
+
+        assert!(out.contains("(window.MILLENNIUM_PLUGIN_LOCALES ||= {})[pluginName] = {};"));
+        assert!(out.contains("(window.MILLENNIUM_PLUGIN_DEPENDENCIES ||= {})[pluginName] = [];"));
+    }
+
+    #[test]
     fn sourcemap_url_absent_when_none() {
         let bundle = "(function() { return {}; })()";
-        let (out, _, _) = wrap(bundle, "test", true, None, &default_inspect(), &[]);
+        let (out, _, _) = wrap(
+            bundle,
+            "test",
+            true,
+            None,
+            &default_inspect(),
+            &[],
+            "{}",
+            "[]",
+        );
         assert!(
             !out.contains("sourceMappingURL"),
             "unexpected sourceMappingURL"

--- a/starlight/src/config.rs
+++ b/starlight/src/config.rs
@@ -183,6 +183,12 @@ pub struct PluginConfig {
     pub version: String,
     pub author: String,
     pub description: Option<String>,
+    /// Plugins this one cannot run without, by id, optionally with a version range.
+    #[serde(default)]
+    pub requires: Vec<String>,
+    /// Plugins this one works with but can run without.
+    #[serde(default)]
+    pub dependencies: Vec<String>,
 }
 
 #[derive(Deserialize)]

--- a/starlight/src/pack.rs
+++ b/starlight/src/pack.rs
@@ -117,6 +117,15 @@ pub fn pack(
         raw_sections.push((SECTION_BACKEND, serialize_sub_entries(&entries)));
     }
 
+    /* a plugin may only translate plugins it declares, so the ids travel with the bundle */
+    let declared_dependencies: Vec<String> = cfg
+        .plugin
+        .requires
+        .iter()
+        .chain(cfg.plugin.dependencies.iter())
+        .map(|spec| spec.split('@').next().unwrap_or(spec).to_string())
+        .collect();
+
     if let Some(frontend_cfg) = &cfg.frontend {
         let (map_disk_path, map_url) = if mode == BuildMode::Debug {
             let sm_dir = prepare_sourcemap_dir(config_dir, "bundle.js.")?;
@@ -149,6 +158,7 @@ pub fn pack(
             &cfg.inspect,
             outro,
             &lua_ffi_names,
+            &declared_dependencies,
         )?;
 
         if !ffi_exposed.is_empty() {
@@ -212,6 +222,7 @@ pub fn pack(
             &cfg.inspect,
             None,
             &lua_ffi_names,
+            &declared_dependencies,
         )?;
 
         if let (Some(path), false) = (&map_disk_path, map_bytes.is_empty()) {


### PR DESCRIPTION
Follow-up to #823, this is the localization half.

Plugins ship a "locales" folder with one JSON file per language, named after Steam's API language code:

```
locales/english.json
locales/russian.json
```

The build embeds them, so a plugin only creates the folder and reads strings through the hook. The plugin name is injected the same way it already is for usePluginConfig, so nothing has to be passed around:

```tsx
const t = useLocalization();
<Field label={t('settingsTitle')} description={t('greeting', 'world')} />
```

Strings resolve against the user's Steam language and fall back to English key by key, so a partial translation only affects the keys it covers, and an unknown key comes back as the key itself.

The part I actually care about is that someone can translate a plugin they don't own, which is what #823 was about. A translation plugin declares the target in its manifest and contributes strings for it:

```ts
// millennium.toml: dependencies = ["some-plugin"]
import russian from '../locales/russian.json';
contributeLocale('some-plugin', 'russian', russian);
```

The target does nothing for this - no integration code, no PRs to accept, no re-release. A plugin can only translate plugins it declares, so the manifest says what it reaches into instead of it being buried in code, and the strings apply no matter which of the two loads first, since the target re-renders when they arrive.

This works with or without #855, the declaration is just a manifest field read at build time. With the dependency work in, the user also gets told what the translation is for when they install it.

Not here: the PluginTemplate side (a locales folder and an example), happy to follow up there.

